### PR TITLE
feat: add navbar, right-side TOC, and blue color theme with dark mode

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -12,6 +12,17 @@ website:
   repo-actions: [edit, issue]
   search: true
 
+  navbar:
+    background: primary
+    left:
+      - text: "Home"
+        href: index.qmd
+      - text: "About"
+        href: about.qmd
+    right:
+      - icon: github
+        href: https://github.com/gjqu/econ-phd-advice
+
   sidebar:
     style: docked
     contents:
@@ -47,6 +58,7 @@ website:
 format:
   html:
     theme:
-      light: cosmo
-      dark: darkly
+      light: [cosmo, custom.scss]
+      dark: [darkly, custom.scss]
     css: styles.css
+    toc: true

--- a/about.qmd
+++ b/about.qmd
@@ -1,0 +1,22 @@
+---
+title: "About"
+---
+
+This site is a curated, community-maintained collection of resources and advice
+for economists at every stage of the academic pipeline — from undergraduates
+considering a PhD to students navigating the job market.
+
+## Origins
+
+The collection was originally created by
+[Chris Roth](https://www.chris-roth.com/) and
+[David Schindler](https://www.davidschindler.org/) as a
+[Google Sites page](https://sites.google.com/view/econgradadvice/). It has been
+migrated to this open-source Quarto website by [Gavin Qu](https://gjqu.github.io/about/) so the community can contribute and
+keep it up to date.
+
+## Contributing
+
+Found a great resource? Spotted a broken link? Contributions are welcome!
+Visit the [GitHub repository](https://github.com/gjqu/econ-phd-advice)
+to open a pull request or file an issue.

--- a/custom.scss
+++ b/custom.scss
@@ -1,0 +1,3 @@
+/*-- scss:defaults --*/
+$primary: #2166AC;
+$link-color: #2166AC;

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
 /* Accent colors — light mode */
 :root {
-  --link-color: #1a6b5a;
-  --link-hover-color: #13503f;
+  --link-color: #2166AC;
+  --link-hover-color: #184e82;
 }
 
 a {
@@ -13,8 +13,8 @@ a:hover {
 
 /* Accent colors — dark mode */
 [data-bs-theme="dark"] {
-  --link-color: #5ec4ab;
-  --link-hover-color: #7fd4bf;
+  --link-color: #6aadeb;
+  --link-hover-color: #91c4f2;
 }
 
 /* Sidebar active page highlight */
@@ -24,8 +24,11 @@ a:hover {
 
 /* Dark mode toggle — larger and more prominent */
 .quarto-color-scheme-toggle {
+  display: flex;
+  align-items: center;
   font-size: 1.4rem;
-  padding: 0.3rem 0.6rem;
+  padding: 0.4rem 0.6rem;
+  margin-bottom: 0.5rem;
   border: 2px solid var(--link-color);
   border-radius: 8px;
   transition: all 0.2s ease;


### PR DESCRIPTION
## Summary
- Add top navbar with Home, About, GitHub icon, and search
- Enable right-side table of contents on all pages
- Add dark mode toggle (cosmo/darkly) with enlarged, styled toggle button
- Override primary color to #2166AC via custom.scss
- Align CSS accent colors with new blue in both light and dark modes
- Add about.qmd page
- Add pre-doc resources to undergrad section

## Test plan
- [ ] Run `quarto preview` and verify blue navbar renders
- [ ] Confirm left sidebar still shows Pre-PhD / During the PhD groupings
- [ ] Confirm right-side "On this page" TOC appears on content pages
- [ ] Toggle light/dark mode and verify colors in both modes
- [ ] Check About page loads from navbar link