### PR TITLE
fix: prevent navbar resize when toggling dark/light mode

### DIFF
--- a/custom.scss
+++ b/custom.scss
@@ -1,3 +1,7 @@
 /*-- scss:defaults --*/
 $primary: #2166AC;
 $link-color: #2166AC;
+
+/* Normalize font size across light (cosmo) and dark (darkly) themes
+   to prevent navbar and layout resizing on theme toggle */
+$font-size-base: 1rem;

--- a/styles.css
+++ b/styles.css
@@ -22,6 +22,20 @@ a:hover {
   color: var(--link-color) !important;
 }
 
+/* Prevent navbar resize when switching between light/dark themes */
+.navbar {
+  min-height: 56px;
+}
+
+.navbar .navbar-brand,
+.navbar .nav-link,
+.navbar .navbar-toggler {
+  font-size: 1rem;
+  line-height: 1.5;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
 /* Dark mode toggle — larger and more prominent */
 .quarto-color-scheme-toggle {
   display: flex;


### PR DESCRIPTION
The darkly theme uses a larger base font size (1.063rem) than cosmo (1rem), causing the navbar to shift height on theme toggle. Normalize $font-size-base to 1rem in custom.scss and pin navbar dimensions in styles.css so the layout stays stable across both themes.

Closes #7