### PR TITLE
fix: update broken Susan Athey link in applying.qmd

### DIFF
--- a/sections/applying.qmd
+++ b/sections/applying.qmd
@@ -6,7 +6,7 @@ Advice on the PhD application process, from choosing programs to writing your st
 
 - [Chris Blattman: Application Advice](https://af4.cf3.mwp.accessdomain.com/about/contact/gradschool/)
 - [Berkeley: Advice on Statements of Purpose](https://grad.berkeley.edu/admissions/steps-to-apply/requirements/statement-purpose/)
-- [Susan Athey: Professional Advice](https://athey.people.stanford.edu/professional-advice)
+- [Susan Athey: Professional Advice](https://gsb-faculty.stanford.edu/susan-athey/professional-advice/)
   — Includes guidance on applying to PhD programs and choosing advisors.
 - [Miles Kimball: The Complete Guide to Getting into an Economics PhD Program](https://qz.com/116081/the-complete-guide-to-getting-into-an-economics-phd-program/)
 - [Elgin et al.: So You Want to Go to Grad School in Economics?](https://drive.google.com/file/d/1KryQkyfcSBDLIY6XKVtcyvp8mv5wrOoZ/view)


### PR DESCRIPTION
Stanford moved her page from athey.people.stanford.edu to gsb-faculty.stanford.edu/susan-athey/. Update to the new URL.