### PR TITLE
fix: normalize navbar padding between cosmo and darkly themes

### DIFF
--- a/custom.scss
+++ b/custom.scss
@@ -5,3 +5,4 @@ $link-color: #2166AC;
 /* Normalize font size across light (cosmo) and dark (darkly) themes
    to prevent navbar and layout resizing on theme toggle */
 $font-size-base: 1rem;
+$navbar-padding-y: 0.5rem;

--- a/styles.css
+++ b/styles.css
@@ -22,20 +22,6 @@ a:hover {
   color: var(--link-color) !important;
 }
 
-/* Prevent navbar resize when switching between light/dark themes */
-.navbar {
-  min-height: 56px;
-}
-
-.navbar .navbar-brand,
-.navbar .nav-link,
-.navbar .navbar-toggler {
-  font-size: 1rem;
-  line-height: 1.5;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-}
-
 /* Dark mode toggle — larger and more prominent */
 .quarto-color-scheme-toggle {
   display: flex;


### PR DESCRIPTION
The darkly theme sets --bs-navbar-padding-y to 1rem while cosmo uses 0.5rem, causing navbar height to change on theme toggle. Override $navbar-padding-y in custom.scss to 0.5rem for both themes and remove the CSS-level navbar overrides that were masking the root cause.