### PR TITLE
fix: replace deprecated --exclude-mail flag in linkcheck workflow

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           args: >-
             --no-progress
-            --exclude-mail
+            --exclude 'mailto:'
             --exclude 'twitter\.com'
             --exclude 'x\.com'
             --exclude 't\.co'


### PR DESCRIPTION
The --exclude-mail flag was removed in newer lychee versions. Use --exclude mailto: pattern instead.