### PR TITLE
fix: normalize font family across light and dark themes

### DIFF
--- a/custom.scss
+++ b/custom.scss
@@ -2,6 +2,10 @@
 $primary: #2166AC;
 $link-color: #2166AC;
 
+/* Normalize font family across light (cosmo) and dark (darkly) themes
+   so switching modes doesn't change perceived text size (fixes #12) */
+$font-family-sans-serif: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
 /* Normalize font size across light (cosmo) and dark (darkly) themes
    to prevent navbar and layout resizing on theme toggle */
 $font-size-base: 1rem;


### PR DESCRIPTION
Cosmo (light) uses Source Sans Pro while Darkly (dark) uses Lato. Lato has a larger x-height, making body text appear bigger at the same CSS pixel size. Override $font-family-sans-serif in custom.scss to force both themes to use Source Sans Pro.

Closes #12