### PR TITLE
fix:exclude domains from linkcheck that returns 403 exit codes

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -29,6 +29,8 @@ jobs:
             --exclude 'twitter\.com'
             --exclude 'x\.com'
             --exclude 't\.co'
+            --exclude 'freakonomics\.com'
+            --exclude 'predoc\.org'
             _site/**/*.html
           fail: false
           output: lychee-report.md


### PR DESCRIPTION
Closes #29, #30 