### PR TITLE
feat: add workflow improvements and expand future plans

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,63 @@
+"section: ai-research":
+  - changed-files:
+    - any-glob-to-any-file: sections/ai-research.qmd
+
+"section: applying":
+  - changed-files:
+    - any-glob-to-any-file: sections/applying.qmd
+
+"section: conferences":
+  - changed-files:
+    - any-glob-to-any-file: sections/conferences.qmd
+
+"section: datasets-coding":
+  - changed-files:
+    - any-glob-to-any-file: sections/datasets-coding.qmd
+
+"section: funding":
+  - changed-files:
+    - any-glob-to-any-file: sections/funding.qmd
+
+"section: general":
+  - changed-files:
+    - any-glob-to-any-file: sections/general.qmd
+
+"section: ideas":
+  - changed-files:
+    - any-glob-to-any-file: sections/ideas.qmd
+
+"section: ideas-to-papers":
+  - changed-files:
+    - any-glob-to-any-file: sections/ideas-to-papers.qmd
+
+"section: job-market":
+  - changed-files:
+    - any-glob-to-any-file: sections/job-market.qmd
+
+"section: mental-health":
+  - changed-files:
+    - any-glob-to-any-file: sections/mental-health.qmd
+
+"section: mentoring":
+  - changed-files:
+    - any-glob-to-any-file: sections/mentoring.qmd
+
+"section: presentations":
+  - changed-files:
+    - any-glob-to-any-file: sections/presentations.qmd
+
+"section: ra-resources":
+  - changed-files:
+    - any-glob-to-any-file: sections/ra-resources.qmd
+
+"section: refereeing":
+  - changed-files:
+    - any-glob-to-any-file: sections/refereeing.qmd
+
+"section: undergrad":
+  - changed-files:
+    - any-glob-to-any-file: sections/undergrad.qmd
+
+"section: writing":
+  - changed-files:
+    - any-glob-to-any-file: sections/writing.qmd

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: Label PRs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -35,6 +35,14 @@ jobs:
           fail: false
           output: lychee-report.md
 
+      - name: Find existing broken links issue
+        id: find-issue
+        run: |
+          ISSUE_NUMBER=$(gh issue list --label broken-link --state open --json number --jq '.[0].number // empty')
+          echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create or update issue with broken links
         if: hashFiles('lychee-report.md') != ''
         uses: peter-evans/create-issue-from-file@v5
@@ -42,4 +50,4 @@ jobs:
           title: "Broken links report"
           content-filepath: lychee-report.md
           labels: broken-link
-          update-existing: true
+          issue-number: ${{ steps.find-issue.outputs.issue_number }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,8 +170,32 @@ PRs should:
 
 ## Future Plans
 
+### Content Expansion
+- **Book recommendations section** — Including open textbooks (tracked in #6)
+- **Econ podcasts & media section** — Podcasts, blogs, and other media (tracked in #15)
+- **Open courses / recorded lectures section** — Curated lecture recordings and courseware (tracked in #23)
+- **Econ RA guide** — Dedicated resource for research assistants (tracked in #25)
+
+### Site Features
 - **Dashboard / visualization layer** — A future phase will add interactive visualizations of the resource collection (e.g., topic clustering, timeline of additions, most-linked domains). This will likely be a separate Quarto dashboard (`.qmd` with `format: dashboard`) or a standalone Observable/D3 page. For now, focus on clean content structure that will make this easy to build later.
-- **Metadata enrichment** — We may eventually add YAML frontmatter metadata to each link (date added, tags, resource type) to power the dashboard. Design section files so this migration is straightforward.
+- **Search & filtering** — Filter resources by tags, resource type (paper, blog, video, tool, course), and career stage (undergrad, early PhD, late PhD, job market)
+- **RSS feed** — Allow users to follow newly added resources
+- **Community contributions page** — Credit contributors to encourage participation
+
+### Workflow & Maintenance
+- **Fix duplicate link check issues** — The weekly lychee link checker currently creates a new issue each run instead of updating the existing one; fix by looking up the existing issue number before creation
+- **Auto-label PRs by section** — Use `actions/labeler` to automatically tag PRs based on which `sections/*.qmd` files they touch
+- **Link archiving** — Auto-submit URLs to the Wayback Machine Save API (monthly) so dead links have a fallback snapshot
+- **Metadata enrichment** — Eventually add structured YAML metadata per resource (title, author, url, type, tags, date_added) to power the dashboard and filtering. Planned schema:
+  ```yaml
+  - title: "Resource Title"
+    author: "Author Name"
+    url: https://example.com
+    type: paper  # paper, blog, video, tool, course
+    tags: [writing, phd]
+    date_added: 2026-03-01
+  ```
+  Defer migration until dashboard work begins; for now, design section files so this is straightforward.
 
 ## Important Notes
 


### PR DESCRIPTION
## Summary
- **Fix linkcheck duplicate issues** — replaced invalid `update-existing` param with a step that finds the existing open `broken-link` issue and passes its number via `issue-number`
- **Add PR auto-labeler** — new `actions/labeler@v5` workflow + config mapping each `sections/*.qmd` to a `section: <name>` label
- **Expand CLAUDE.md Future Plans** — added content expansion ideas (linking open issues #6, #15, #23, #25), site features, and workflow maintenance items

Closes #29, closes #30

## Setup needed
- Create `section: *` labels in repo settings for the auto-labeler to apply them

## Test plan
- [x] Trigger linkcheck workflow manually via `workflow_dispatch` and verify it updates the existing issue instead of creating a new one
- [x] Open a test PR touching a section file and verify the label is applied
